### PR TITLE
Drop bower, update a few packages to minimum latest to allow removing…

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "analytics": false
-}

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,0 @@
-{
-  "name": "ds-inline-edit",
-  "dependencies": {
-    "ember": "~2.9.0",
-    "ember-cli-shims": "0.1.3"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -26,15 +26,16 @@
   "devDependencies": {
     "broccoli-asset-rev": "2.4.5",
     "ember-ajax": "2.4.1",
-    "ember-cli": "2.9.1",
+    "ember-cli": "2.11.1",
     "ember-cli-app-version": "2.0.0",
     "ember-cli-dependency-checker": "1.3.0",
-    "ember-cli-htmlbars-inline-precompile": "0.3.3",
+    "ember-cli-htmlbars-inline-precompile": "1.0.2",
     "ember-cli-inject-live-reload": "1.4.1",
     "ember-cli-jshint": "1.0.4",
     "ember-cli-mirage": "0.2.4",
     "ember-cli-qunit": "3.0.1",
     "ember-cli-release": "0.2.9",
+    "ember-cli-shims": "1.1.0",
     "ember-cli-sri": "2.1.0",
     "ember-cli-test-loader": "1.1.0",
     "ember-cli-uglify": "1.2.0",
@@ -43,14 +44,15 @@
     "ember-export-application-global": "1.0.5",
     "ember-load-initializers": "0.5.1",
     "ember-resolver": "2.0.3",
+    "ember-source": "2.11.3",
     "loader.js": "4.0.10"
   },
   "keywords": [
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "5.1.7",
-    "ember-cli-htmlbars": "1.0.10"
+    "ember-cli-babel": "6.8.1",
+    "ember-cli-htmlbars": "1.3.4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
… bower from project

* Tested locally with Chrome headless
* Tested in app
* Only updated package versions up until bower removal from Ember

**Why the pull request?**
When compiling my app, I was getting a nasty bower dependency error, which was weird because I'm not using bower. After tracing it back to this package, the bug was in a version of `ember-cli-htmlbars-inline-precompile`.

https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile/issues/71

Great addon, thanks!